### PR TITLE
feat: config helper method

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,13 @@ from rdf4j_python.model import MemoryStoreConfig, RepositoryConfig
 from rdf4j_python.utils.const import Rdf4jContentType
 
 async with AsyncRdf4j("http://localhost:19780/rdf4j-server") as db:
-    repo_config = RepositoryConfig.with_sail_repository(
-        repo_id="example-repo",
-        sail_impl=MemoryStoreConfig.Builder().persist(False).build(),
+    repo_config = (
+        RepositoryConfig.builder_with_sail_repository(
+            MemoryStoreConfig.Builder().persist(False).build(),
+        )
+        .repo_id("example-repo")
+        .title("Example Repository")
+        .build()
     )
     await db.create_repository(
         repository_id=repo_config.repo_id,

--- a/README.md
+++ b/README.md
@@ -27,10 +27,20 @@ pip install rdf4j-python
 Here's a basic example of how to use `rdf4j-python`:
 
 ```python
-from rdf4j_python import AsyncRDF4JDB
+from rdf4j_python import AsyncRdf4j
+from rdf4j_python.model import MemoryStoreConfig, RepositoryConfig
+from rdf4j_python.utils.const import Rdf4jContentType
 
-async with AsyncRDF4JDB() as db:
-    await db.create_repository("my_repo")
+async with AsyncRdf4j("http://localhost:19780/rdf4j-server") as db:
+    repo_config = RepositoryConfig.with_sail_repository(
+        repo_id="example-repo",
+        sail_impl=MemoryStoreConfig.Builder().persist(False).build(),
+    )
+    await db.create_repository(
+        repository_id=repo_config.repo_id,
+        rdf_config_data=repo_config.to_turtle(),
+        content_type=Rdf4jContentType.TURTLE,
+    )
 ```
 
 For more detailed examples, refer to the [examples](https://github.com/odysa/rdf4j-python/tree/main/examples) directory.

--- a/examples/repo.py
+++ b/examples/repo.py
@@ -1,39 +1,21 @@
 import asyncio
-import textwrap
 
 from rdf4j_python import AsyncRdf4j
+from rdf4j_python.model import MemoryStoreConfig, RepositoryConfig
+from rdf4j_python.utils.const import Rdf4jContentType
 
 
 async def main():
     async with AsyncRdf4j("http://localhost:19780/rdf4j-server") as db:
-        repositories = await db.list_repositories()
-        print("Repositories:", repositories)
-
-        version = await db.get_protocol_version()
-        print("Protocol Version:", version)
-
-        repo_config = textwrap.dedent(
-            """
-            @prefix config: <tag:rdf4j.org,2023:config/>.
-            [] a config:Repository ;
-            config:rep.id "example-repo" ;
-            config:rep.impl [
-                config:rep.type "openrdf:SailRepository" ;
-                config:sail.impl [
-                    config:sail.type "openrdf:MemoryStore" ;
-                ]
-            ] .
-        """
+        repo_config = RepositoryConfig.with_sail_repository(
+            repo_id="example-repo",
+            sail_impl=MemoryStoreConfig.Builder().persist(False).build(),
         )
         await db.create_repository(
-            repository_id="example-repo",
-            rdf_config_data=repo_config,
-            content_type="application/x-turtle",
+            repository_id=repo_config.repo_id,
+            rdf_config_data=repo_config.to_turtle(),
+            content_type=Rdf4jContentType.TURTLE,
         )
-        print("Repository 'example-repo' created.")
-        # List repositories again to confirm creation
-        repositories = await db.list_repositories()
-        print("Repositories after creation:", repositories)
 
 
 if __name__ == "__main__":

--- a/examples/repo.py
+++ b/examples/repo.py
@@ -7,9 +7,13 @@ from rdf4j_python.utils.const import Rdf4jContentType
 
 async def main():
     async with AsyncRdf4j("http://localhost:19780/rdf4j-server") as db:
-        repo_config = RepositoryConfig.with_sail_repository(
-            repo_id="example-repo",
-            sail_impl=MemoryStoreConfig.Builder().persist(False).build(),
+        repo_config = (
+            RepositoryConfig.builder_with_sail_repository(
+                MemoryStoreConfig.Builder().persist(False).build(),
+            )
+            .repo_id("example-repo")
+            .title("Example Repository")
+            .build()
         )
         await db.create_repository(
             repository_id=repo_config.repo_id,

--- a/rdf4j_python/_driver/_async_rdf4j_db.py
+++ b/rdf4j_python/_driver/_async_rdf4j_db.py
@@ -8,7 +8,7 @@ from rdf4j_python.exception.repo_exception import (
     RepositoryCreationException,
     RepositoryDeletionException,
 )
-from rdf4j_python.model._repository_info import RepositoryInfo
+from rdf4j_python.model._repository_info import RepositoryMetadata
 from rdf4j_python.utils.const import Rdf4jContentType
 
 from ._async_repository import AsyncRdf4JRepository
@@ -33,7 +33,7 @@ class AsyncRdf4j:
         response.raise_for_status()
         return response.text
 
-    async def list_repositories(self) -> list[RepositoryInfo]:
+    async def list_repositories(self) -> list[RepositoryMetadata]:
         """
         List all RDF4J repositories.
 
@@ -48,7 +48,8 @@ class AsyncRdf4j:
         )
 
         return [
-            RepositoryInfo.from_rdflib_binding(binding) for binding in result.bindings
+            RepositoryMetadata.from_rdflib_binding(binding)
+            for binding in result.bindings
         ]
 
     async def get_repository(self, repository_id: str) -> AsyncRdf4JRepository:

--- a/rdf4j_python/model/__init__.py
+++ b/rdf4j_python/model/__init__.py
@@ -1,5 +1,16 @@
 from ._namespace import IRI, Namespace
-from ._repository_config import RepositoryConfig
-from ._repository_info import RepositoryInfo
+from ._repository_config import (
+    MemoryStoreConfig,
+    NativeStoreConfig,
+    RepositoryConfig,
+)
+from ._repository_info import RepositoryMetadata
 
-__all__ = ["IRI", "Namespace", "RepositoryConfig", "RepositoryInfo"]
+__all__ = [
+    "IRI",
+    "Namespace",
+    "RepositoryConfig",
+    "MemoryStoreConfig",
+    "NativeStoreConfig",
+    "RepositoryMetadata",
+]

--- a/rdf4j_python/model/_repository_config.py
+++ b/rdf4j_python/model/_repository_config.py
@@ -56,6 +56,24 @@ class RepositoryConfig:
 
         return graph.serialize(format="turtle").encode("utf-8")
 
+    @staticmethod
+    def with_sail_repository(
+        repo_id: str,
+        sail_impl: "SailConfig",
+        title: Optional[str] = None,
+    ) -> "RepositoryConfig":
+        """
+        Convenience method to create a RepositoryConfig with a SailRepositoryConfig.
+        """
+
+        repo_config = RepositoryConfig.Builder(repo_id).repo_impl(
+            SailRepositoryConfig.Builder().sail_impl(sail_impl).build()
+        )
+        if title:
+            repo_config.title(title)
+
+        return repo_config.build()
+
     class Builder:
         """
         Builder class for creating RepositoryConfig instances.

--- a/rdf4j_python/model/_repository_config.py
+++ b/rdf4j_python/model/_repository_config.py
@@ -57,22 +57,18 @@ class RepositoryConfig:
         return graph.serialize(format="turtle").encode("utf-8")
 
     @staticmethod
-    def with_sail_repository(
-        repo_id: str,
+    def builder_with_sail_repository(
         sail_impl: "SailConfig",
-        title: Optional[str] = None,
-    ) -> "RepositoryConfig":
+    ) -> "RepositoryConfig.Builder":
         """
         Convenience method to create a RepositoryConfig with a SailRepositoryConfig.
         """
 
-        repo_config = RepositoryConfig.Builder(repo_id).repo_impl(
+        repo_config = RepositoryConfig.Builder().repo_impl(
             SailRepositoryConfig.Builder().sail_impl(sail_impl).build()
         )
-        if title:
-            repo_config.title(title)
 
-        return repo_config.build()
+        return repo_config
 
     class Builder:
         """

--- a/rdf4j_python/model/_repository_info.py
+++ b/rdf4j_python/model/_repository_info.py
@@ -7,9 +7,9 @@ from ._base_model import _BaseModel
 
 
 @dataclass
-class RepositoryInfo(_BaseModel):
+class RepositoryMetadata(_BaseModel):
     """
-    Represents a repository information RDF4J.
+    Represents a repository metadata RDF4J.
     """
 
     id: str  # The repository identifier
@@ -25,7 +25,7 @@ class RepositoryInfo(_BaseModel):
     @classmethod
     def from_rdflib_binding(
         cls, result: Mapping[Variable, Identifier]
-    ) -> "RepositoryInfo":
+    ) -> "RepositoryMetadata":
         """
         Create a Repository instance from a SPARQL query result
         represented as a Mapping from rdflib Variables to Identifiers.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,11 +37,14 @@ def rdf4j_service(docker_ip: str, docker_services) -> str:
 @pytest.fixture(scope="function")
 def random_mem_repo_config() -> RepositoryConfig:
     repo_id = f"test_repo_{str(randint(1, 1000000))}"
-    return RepositoryConfig.with_sail_repository(
-        repo_id=repo_id,
-        sail_impl=MemoryStoreConfig.Builder()
-        .persist(False)
-        .iteration_cache_sync_threshold(1000)
-        .build(),
-        title=repo_id,
+    return (
+        RepositoryConfig.builder_with_sail_repository(
+            MemoryStoreConfig.Builder()
+            .persist(False)
+            .iteration_cache_sync_threshold(1000)
+            .build(),
+        )
+        .repo_id(repo_id)
+        .title(repo_id)
+        .build()
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ import pytest
 from rdf4j_python.model._repository_config import (
     MemoryStoreConfig,
     RepositoryConfig,
-    SailRepositoryConfig,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -38,13 +37,11 @@ def rdf4j_service(docker_ip: str, docker_services) -> str:
 @pytest.fixture(scope="function")
 def random_mem_repo_config() -> RepositoryConfig:
     repo_id = f"test_repo_{str(randint(1, 1000000))}"
-    return (
-        RepositoryConfig.Builder(repo_id)
-        .title(repo_id)
-        .repo_impl(
-            SailRepositoryConfig.Builder(
-                sail_impl=MemoryStoreConfig.Builder().persist(False).build()
-            ).build()
-        )
-        .build()
+    return RepositoryConfig.with_sail_repository(
+        repo_id=repo_id,
+        sail_impl=MemoryStoreConfig.Builder()
+        .persist(False)
+        .iteration_cache_sync_threshold(1000)
+        .build(),
+        title=repo_id,
     )

--- a/tests/model/test_repository_info.py
+++ b/tests/model/test_repository_info.py
@@ -2,7 +2,7 @@ import pytest
 import rdflib
 from rdflib.term import Literal, URIRef, Variable
 
-from rdf4j_python.model._repository_info import RepositoryInfo
+from rdf4j_python.model._repository_info import RepositoryMetadata
 
 
 @pytest.fixture
@@ -41,7 +41,7 @@ def partial_result():
 
 def test_from_rdflib_valid(valid_result: rdflib.query.Result):
     for binding in valid_result.bindings:
-        repo = RepositoryInfo.from_rdflib_binding(binding)
+        repo = RepositoryMetadata.from_rdflib_binding(binding)
         assert repo.id == "example-repo" + str(binding[Variable("id")].value[-1])
         assert repo.title == "example-repo" + str(binding[Variable("id")].value[-1])
         assert (
@@ -54,7 +54,7 @@ def test_from_rdflib_valid(valid_result: rdflib.query.Result):
 
 
 def test_from_rdflib_partial(partial_result: rdflib.query.Result):
-    repo = RepositoryInfo.from_rdflib_binding(partial_result.bindings[0])
+    repo = RepositoryMetadata.from_rdflib_binding(partial_result.bindings[0])
     assert repo.id == "partial-repo"
     assert repo.title == "partial-repo"
     assert repo.uri == ""
@@ -64,7 +64,7 @@ def test_from_rdflib_partial(partial_result: rdflib.query.Result):
 
 def test_str_representation(valid_result: rdflib.query.Result):
     for binding in valid_result.bindings:
-        repo = RepositoryInfo.from_rdflib_binding(binding)
+        repo = RepositoryMetadata.from_rdflib_binding(binding)
         assert (
             str(repo) == f"Repository(id={repo.id}, title={repo.title}, uri={repo.uri})"
         )


### PR DESCRIPTION
This PR renames the RepositoryInfo class to RepositoryMetadata and updates the repository configuration helper methods to streamline creation using the new builder_with_sail_repository method.

Renamed RepositoryInfo to RepositoryMetadata across tests, models, and driver files.
Introduced a builder_with_sail_repository static method in RepositoryConfig to facilitate Sail repository configuration.
Updated examples and documentation to reflect these changes.
