### PR TITLE
feat: update repository creation and add statement retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,24 +31,23 @@ pip install rdf4j-python
 Here's a basic example of how to use `rdf4j-python` to create an in-memory sail repository
 
 ```python
-from rdf4j_python import AsyncRdf4j
-from rdf4j_python.model import MemoryStoreConfig, RepositoryConfig
-from rdf4j_python.utils.const import Rdf4jContentType
-
 async with AsyncRdf4j("http://localhost:19780/rdf4j-server") as db:
     repo_config = (
-        RepositoryConfig.builder_with_sail_repository(
-            MemoryStoreConfig.Builder().persist(False).build(),
-        )
+        RepositoryConfig.Builder()
         .repo_id("example-repo")
         .title("Example Repository")
+        .sail_repository_impl(
+            MemoryStoreConfig.Builder().persist(False).build(),
+        )
         .build()
     )
-    await db.create_repository(
-        repository_id=repo_config.repo_id,
-        rdf_config_data=repo_config.to_turtle(),
-        content_type=Rdf4jContentType.TURTLE,
+    repo = await db.create_repository(config=repo_config)
+    await repo.add_statement(
+        IRI("http://example.com/subject"),
+        IRI("http://example.com/predicate"),
+        Literal("test_object"),
     )
+    await repo.get_statements(subject=IRI("http://example.com/subject"))
 ```
 
 For more detailed examples, refer to the [examples](https://github.com/odysa/rdf4j-python/tree/main/examples) directory.

--- a/examples/repo.py
+++ b/examples/repo.py
@@ -3,9 +3,7 @@ import asyncio
 from rdflib import Literal
 
 from rdf4j_python import AsyncRdf4j
-from rdf4j_python.model import RepositoryConfig
-from rdf4j_python.model._repository_config import MemoryStoreConfig
-from rdf4j_python.model._term import IRI
+from rdf4j_python.model import IRI, MemoryStoreConfig, RepositoryConfig
 
 
 async def main():

--- a/examples/repo.py
+++ b/examples/repo.py
@@ -1,25 +1,31 @@
 import asyncio
 
+from rdflib import Literal
+
 from rdf4j_python import AsyncRdf4j
-from rdf4j_python.model import MemoryStoreConfig, RepositoryConfig
-from rdf4j_python.utils.const import Rdf4jContentType
+from rdf4j_python.model import RepositoryConfig
+from rdf4j_python.model._repository_config import MemoryStoreConfig
+from rdf4j_python.model._term import IRI
 
 
 async def main():
     async with AsyncRdf4j("http://localhost:19780/rdf4j-server") as db:
         repo_config = (
-            RepositoryConfig.builder_with_sail_repository(
+            RepositoryConfig.Builder()
+            .repo_id("example-repo-2")
+            .title("Example Repository")
+            .sail_repository_impl(
                 MemoryStoreConfig.Builder().persist(False).build(),
             )
-            .repo_id("example-repo")
-            .title("Example Repository")
             .build()
         )
-        await db.create_repository(
-            repository_id=repo_config.repo_id,
-            rdf_config_data=repo_config.to_turtle(),
-            content_type=Rdf4jContentType.TURTLE,
+        repo = await db.create_repository(config=repo_config)
+        await repo.add_statement(
+            IRI("http://example.com/subject"),
+            IRI("http://example.com/predicate"),
+            Literal("test_object"),
         )
+        await repo.get_statements(subject=IRI("http://example.com/subject"))
 
 
 if __name__ == "__main__":

--- a/rdf4j_python/model/_repository_config.py
+++ b/rdf4j_python/model/_repository_config.py
@@ -56,20 +56,6 @@ class RepositoryConfig:
 
         return graph.serialize(format="turtle").encode("utf-8")
 
-    @staticmethod
-    def builder_with_sail_repository(
-        sail_impl: "SailConfig",
-    ) -> "RepositoryConfig.Builder":
-        """
-        Convenience method to create a RepositoryConfig with a SailRepositoryConfig.
-        """
-
-        repo_config = RepositoryConfig.Builder().repo_impl(
-            SailRepositoryConfig.Builder().sail_impl(sail_impl).build()
-        )
-
-        return repo_config
-
     class Builder:
         """
         Builder class for creating RepositoryConfig instances.
@@ -99,6 +85,15 @@ class RepositoryConfig:
             Sets the repository implementation configuration.
             """
             self._impl = impl
+            return self
+
+        def sail_repository_impl(
+            self, sail_impl: "SailConfig"
+        ) -> "RepositoryConfig.Builder":
+            """
+            Sets the repository implementation configuration to a SailRepositoryConfig.
+            """
+            self.repo_impl(SailRepositoryConfig.Builder().sail_impl(sail_impl).build())
             return self
 
         def build(self) -> "RepositoryConfig":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,6 @@ from rdf4j_python.model._repository_config import (
     MemoryStoreConfig,
     RepositoryConfig,
 )
-from rdf4j_python.utils.const import Rdf4jContentType
 
 LOGGER = logging.getLogger(__name__)
 
@@ -43,9 +42,7 @@ async def mem_repo(rdf4j_service: str, random_mem_repo_config: RepositoryConfig)
 
     async with AsyncRdf4j(rdf4j_service) as db:
         repo = await db.create_repository(
-            repository_id=random_mem_repo_config.repo_id,
-            rdf_config_data=random_mem_repo_config.to_turtle(),
-            content_type=Rdf4jContentType.TURTLE,
+            config=random_mem_repo_config,
         )
         yield repo
         await db.delete_repository(random_mem_repo_config.repo_id)
@@ -56,13 +53,11 @@ def random_mem_repo_config() -> RepositoryConfig:
     """Fixture that yields a random memory repository configuration."""
     repo_id = f"test_repo_{str(randint(1, 1000000))}"
     return (
-        RepositoryConfig.builder_with_sail_repository(
-            MemoryStoreConfig.Builder()
-            .persist(False)
-            .iteration_cache_sync_threshold(1000)
-            .build(),
-        )
+        RepositoryConfig.Builder()
         .repo_id(repo_id)
         .title(repo_id)
+        .sail_repository_impl(
+            MemoryStoreConfig.Builder().persist(False).build(),
+        )
         .build()
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,10 +52,11 @@ async def mem_repo(rdf4j_service: str, random_mem_repo_config: RepositoryConfig)
 def random_mem_repo_config() -> RepositoryConfig:
     """Fixture that yields a random memory repository configuration."""
     repo_id = f"test_repo_{str(randint(1, 1000000))}"
+    title = f"test_repo_{str(randint(1, 1000000))}_title"
     return (
         RepositoryConfig.Builder()
         .repo_id(repo_id)
-        .title(repo_id)
+        .title(title)
         .sail_repository_impl(
             MemoryStoreConfig.Builder().persist(False).build(),
         )

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -4,5 +4,5 @@ services:
   rdf4j:
     image: eclipse/rdf4j-workbench:latest
     ports:
-      - "19780:8080"
+      - '19780:8080'
     restart: unless-stopped

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,36 +4,17 @@ from rdf4j_python import AsyncRdf4j
 from rdf4j_python.model import MemoryStoreConfig, RepositoryConfig
 
 
-def get_repo_config(name: str):
-    return f"""
-        @prefix config: <tag:rdf4j.org,2023:config/>.
-
-        [] a config:Repository ;
-        config:rep.id "{name}" ;
-        rdfs:label "{name}" ;
-        config:rep.impl [
-            config:rep.type "openrdf:SailRepository" ;
-            config:sail.impl [
-                config:sail.type "openrdf:MemoryStore" ;
-            ]
-        ] .
-    """
-
-
 @pytest.mark.asyncio
 async def test_create_repo(
     rdf4j_service: str, random_mem_repo_config: RepositoryConfig
 ):
     async with AsyncRdf4j(rdf4j_service) as db:
-        repo_id = "test_create_repo"
-        await db.create_repository(
-            config=random_mem_repo_config,
-        )
+        await db.create_repository(config=random_mem_repo_config)
         repos = await db.list_repositories()
         assert len(repos) == 1
-        assert repos[0].id == repo_id
-        assert repos[0].title == repo_id
-        await db.delete_repository(repo_id)
+        assert repos[0].id == random_mem_repo_config.repo_id
+        assert repos[0].title == random_mem_repo_config.title
+        await db.delete_repository(random_mem_repo_config.repo_id)
 
 
 @pytest.mark.asyncio
@@ -47,7 +28,7 @@ async def test_delete_repo(
         repos = await db.list_repositories()
         assert len(repos) == 1
         assert repos[0].id == random_mem_repo_config.repo_id
-        assert repos[0].title == random_mem_repo_config.repo_id
+        assert repos[0].title == random_mem_repo_config.title
         await db.delete_repository(random_mem_repo_config.repo_id)
         repos = await db.list_repositories()
         assert len(repos) == 0
@@ -61,9 +42,11 @@ async def test_list_repos(rdf4j_service: str):
         assert len(repos) == 0
         for repo in range(repo_count):
             repo_id = f"test_list_repos_{repo}"
+            title = f"test_list_repos_{repo}_title"
             repo_config = (
                 RepositoryConfig.Builder()
                 .repo_id(repo_id)
+                .title(title)
                 .sail_repository_impl(
                     MemoryStoreConfig.Builder().persist(False).build()
                 )
@@ -72,12 +55,12 @@ async def test_list_repos(rdf4j_service: str):
             await db.create_repository(
                 config=repo_config,
             )
-        repos = await db.list_repositories()
-        assert len(repos) == repo_count
+        repo_list = await db.list_repositories()
+        assert len(repo_list) == repo_count
         for repo in range(repo_count):
-            repo_id = f"test_list_repos_{repo}"
-            assert repo_id in [repo.id for repo in repos]
-            assert repo_id in [repo.title for repo in repos]
+            assert f"test_list_repos_{repo}" in [repo.id for repo in repo_list]
+            assert f"test_list_repos_{repo}_title" in [repo.title for repo in repo_list]
+            await db.delete_repository(f"test_list_repos_{repo}")
 
 
 @pytest.mark.asyncio
@@ -88,3 +71,8 @@ async def test_create_memory_store_repo(
         await db.create_repository(
             config=random_mem_repo_config,
         )
+        repo_list = await db.list_repositories()
+        assert len(repo_list) == 1
+        assert repo_list[0].id == random_mem_repo_config.repo_id
+        assert repo_list[0].title == random_mem_repo_config.title
+        await db.delete_repository(random_mem_repo_config.repo_id)


### PR DESCRIPTION
This PR refactors repository creation to use a RepositoryConfig builder and adds example calls for adding and retrieving statements. It also updates tests and documentation to align with the new API.

Switch AsyncRdf4j.create_repository to accept RepositoryConfig instead of raw RDF and content type.
Update tests and fixtures to use MemoryStoreConfig and the new builder pattern.
Refresh examples and README to demonstrate statement addition and retrieval.