### PR TITLE
fix: client init issue

### DIFF
--- a/rdf4j_python/_client/_client.py
+++ b/rdf4j_python/_client/_client.py
@@ -273,3 +273,9 @@ class AsyncApiClient(BaseClient):
         return await self.client.delete(
             self._build_url(path), params=params, headers=headers
         )
+
+    async def aclose(self):
+        """
+        Asynchronously closes the client connection.
+        """
+        await self.client.aclose()

--- a/rdf4j_python/_driver/_async_rdf4j_db.py
+++ b/rdf4j_python/_driver/_async_rdf4j_db.py
@@ -26,6 +26,7 @@ class AsyncRdf4j:
             base_url (str): Base URL of the RDF4J server.
         """
         self._base_url = base_url.rstrip("/")
+        self._client = AsyncApiClient(base_url=self._base_url)
 
     async def __aenter__(self):
         """Enters the async context and initializes the HTTP client.
@@ -33,7 +34,7 @@ class AsyncRdf4j:
         Returns:
             AsyncRdf4j: The initialized RDF4J interface.
         """
-        self._client = await AsyncApiClient(base_url=self._base_url).__aenter__()
+        self._client = await self._client.__aenter__()
         return self
 
     async def __aexit__(self, exc_type, exc_value, traceback):
@@ -103,7 +104,7 @@ class AsyncRdf4j:
             RepositoryCreationException: If repository creation fails.
         """
         path = f"/repositories/{config.repo_id}"
-        headers = {"Content-Type": Rdf4jContentType.TURTLE}
+        headers = {"Content-Type": Rdf4jContentType.TURTLE.value}
         response: httpx.Response = await self._client.put(
             path, content=config.to_turtle(), headers=headers
         )
@@ -128,3 +129,7 @@ class AsyncRdf4j:
             raise RepositoryDeletionException(
                 f"Failed to delete repository '{repository_id}': {response.status_code} - {response.text}"
             )
+
+    async def aclose(self):
+        """Asynchronously closes the client connection."""
+        await self._client.aclose()

--- a/tests/model/test_namespace.py
+++ b/tests/model/test_namespace.py
@@ -69,6 +69,7 @@ def test_namespace_from_sparql_query_solution():
         .to_json(),
         format=og.QueryResultsFormat.JSON,
     )
+    assert isinstance(query_solution, og.QuerySolutions)
     namespace = Namespace.from_sparql_query_solution(next(query_solution))
     assert namespace.prefix == "ex"
     assert namespace.namespace.value == "http://example.org/"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -20,7 +20,7 @@ async def test_create_repo(
         assert repos[0].title == random_mem_repo_config.title
         await db.delete_repository(random_mem_repo_config.repo_id)
 
-    # test with out async context manager
+    # test without async context manager
     db = AsyncRdf4j(rdf4j_service)
     await db.create_repository(config=random_mem_repo_config)
     repos = await db.list_repositories()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -20,6 +20,16 @@ async def test_create_repo(
         assert repos[0].title == random_mem_repo_config.title
         await db.delete_repository(random_mem_repo_config.repo_id)
 
+    # test with out async context manager
+    db = AsyncRdf4j(rdf4j_service)
+    await db.create_repository(config=random_mem_repo_config)
+    repos = await db.list_repositories()
+    assert len(repos) == 1
+    assert repos[0].id == random_mem_repo_config.repo_id
+    assert repos[0].title == random_mem_repo_config.title
+    await db.delete_repository(random_mem_repo_config.repo_id)
+    await db.aclose()
+
 
 @pytest.mark.asyncio
 async def test_delete_repo(
@@ -36,6 +46,18 @@ async def test_delete_repo(
         await db.delete_repository(random_mem_repo_config.repo_id)
         repos = await db.list_repositories()
         assert len(repos) == 0
+
+    # test with out async context manager
+    db = AsyncRdf4j(rdf4j_service)
+    await db.create_repository(config=random_mem_repo_config)
+    repos = await db.list_repositories()
+    assert len(repos) == 1
+    assert repos[0].id == random_mem_repo_config.repo_id
+    assert repos[0].title == random_mem_repo_config.title
+    await db.delete_repository(random_mem_repo_config.repo_id)
+    repos = await db.list_repositories()
+    assert len(repos) == 0
+    await db.aclose()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix async client initialization in AsyncRdf4j class

- Add proper client cleanup with aclose() methods

- Fix content type enum usage bug

- Add tests for non-context manager usage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AsyncRdf4j.__init__"] --> B["Initialize AsyncApiClient"]
  B --> C["__aenter__ uses existing client"]
  C --> D["Add aclose() methods"]
  D --> E["Fix content type enum usage"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_client.py</strong><dd><code>Add async client cleanup method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rdf4j_python/_client/_client.py

- Add `aclose()` method for proper async client cleanup


</details>


  </td>
  <td><a href="https://github.com/odysa/rdf4j-python/pull/40/files#diff-50c18ed877a67bb7d7eebe4dbb20311d98b06fcd2e41b6703790fdf7bdab5a0c">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_async_rdf4j_db.py</strong><dd><code>Fix client initialization and cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rdf4j_python/_driver/_async_rdf4j_db.py

<ul><li>Move client initialization from <code>__aenter__</code> to <code>__init__</code><br> <li> Fix content type enum usage by adding <code>.value</code><br> <li> Add <code>aclose()</code> method for client cleanup</ul>


</details>


  </td>
  <td><a href="https://github.com/odysa/rdf4j-python/pull/40/files#diff-ffb39dc021e6db7d8f339356f4778c35221b08f8539d6d67f42744b0f8e8f72f">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_namespace.py</strong><dd><code>Add query solution type assertion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/model/test_namespace.py

- Add type assertion for query solution object


</details>


  </td>
  <td><a href="https://github.com/odysa/rdf4j-python/pull/40/files#diff-1081a934ac2a5a975402172b2325be9bbacbc8cb9c49c4414d2baf21827cd7ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_client.py</strong><dd><code>Add non-context manager usage tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_client.py

<ul><li>Add tests for using AsyncRdf4j without context manager<br> <li> Test proper cleanup with <code>aclose()</code> method calls</ul>


</details>


  </td>
  <td><a href="https://github.com/odysa/rdf4j-python/pull/40/files#diff-0d92063e88430a02df61616c5f16b148b64ac4539d9cb9b8d883d5a23351b110">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

